### PR TITLE
feat: Add Order use case examples

### DIFF
--- a/samples/order/use-cases/UC1_Order.xml
+++ b/samples/order/use-cases/UC1_Order.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Order xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Order-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:order_only:3</cbc:ProfileID>
+  <cbc:ID>1</cbc:ID>
+  <cbc:IssueDate>2013-07-01</cbc:IssueDate>
+  <cbc:IssueTime>05:10:10</cbc:IssueTime>
+   <cbc:DocumentCurrencyCode listID="ISO4217">EUR</cbc:DocumentCurrencyCode>
+  <cbc:AccountingCost>MAFO</cbc:AccountingCost>
+  <cac:ValidityPeriod>
+    <cbc:EndDate>2013-07-30</cbc:EndDate>
+  </cac:ValidityPeriod>
+  <cac:Contract>
+    <cbc:ID>C1</cbc:ID>
+  </cac:Contract>
+  <cac:BuyerCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">7300010000001</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>City Hospital</cbc:Name>
+      </cac:PartyName>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>City Hospital 345433</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0088">7300010000001</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:CityName>Eurocity</cbc:CityName>
+          <cac:Country>
+            <cbc:IdentificationCode listID="ISO3166-1:Alpha2">SE</cbc:IdentificationCode>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>Martin Foggerty</cbc:Name>
+        <cbc:Telephone>+46555785488</cbc:Telephone>
+        <cbc:ElectronicMail>martin.foggerty@cityhospital.se</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:BuyerCustomerParty>
+  <cac:SellerSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0192">987654325</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0192">987654325</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:StreetName>Harbour street</cbc:StreetName>
+        <cbc:AdditionalStreetName>Dock 45</cbc:AdditionalStreetName>
+        <cbc:CityName>Bergen</cbc:CityName>
+        <cbc:PostalZone>5005</cbc:PostalZone>
+        <cbc:CountrySubentity>Region West</cbc:CountrySubentity>
+        <cac:AddressLine>
+          <cbc:Line>Gate 34</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode>NO</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>The Supplier AB</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:SellerSupplierParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Lower street 5</cbc:StreetName>
+        <cbc:AdditionalStreetName>Reception</cbc:AdditionalStreetName>
+        <cbc:CityName>Stockholm</cbc:CityName>
+        <cbc:PostalZone>11120</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">SE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+    <cac:RequestedDeliveryPeriod>
+      <cbc:StartDate>2013-07-15</cbc:StartDate>
+      <cbc:EndDate>2013-07-16</cbc:EndDate>
+    </cac:RequestedDeliveryPeriod>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>Hospital Tourist Department</cbc:Name>
+      </cac:PartyName>
+      <cac:Contact>
+        <cbc:Name>John</cbc:Name>
+        <cbc:Telephone>+465558877523</cbc:Telephone>
+        <cbc:ElectronicMail>john@cityhospital.se</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:TaxTotal>
+		<cbc:TaxAmount currencyID="EUR">28.75</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:AnticipatedMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">115</cbc:LineExtensionAmount>
+    <cbc:PayableAmount currencyID="EUR">143.75</cbc:PayableAmount>
+  </cac:AnticipatedMonetaryTotal>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>1</cbc:ID>
+      <cbc:Quantity unitCode="NAR" unitCodeListID="UNECERec20">10</cbc:Quantity>
+      <cbc:LineExtensionAmount currencyID="EUR">40</cbc:LineExtensionAmount>
+      <cbc:AccountingCost>MAFO-1</cbc:AccountingCost>
+      <cac:Price>
+        <cbc:PriceAmount currencyID="EUR">4</cbc:PriceAmount>
+      </cac:Price>
+       <cac:Item>
+        <cbc:Description>1x12 pack sauce bags</cbc:Description>
+        <cbc:Name>Brown sauce</cbc:Name>
+        <cac:SellersItemIdentification>
+          <cbc:ID>SN-33</cbc:ID>
+        </cac:SellersItemIdentification>
+        <cac:StandardItemIdentification>
+          <cbc:ID schemeID="0160">05704066204093</cbc:ID>
+        </cac:StandardItemIdentification>
+        <cac:ClassifiedTaxCategory>
+          <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:ClassifiedTaxCategory>
+        </cac:Item>
+    </cac:LineItem>
+  </cac:OrderLine>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>2</cbc:ID>
+      <cbc:Quantity unitCode="NAR" unitCodeListID="UNECERec20">5</cbc:Quantity>
+      <cbc:LineExtensionAmount currencyID="EUR">30</cbc:LineExtensionAmount>
+      <cbc:AccountingCost>MAFO-1</cbc:AccountingCost>
+      <cac:Price>
+        <cbc:PriceAmount currencyID="EUR">6</cbc:PriceAmount>
+      </cac:Price>
+       <cac:Item>
+        <cbc:Description>1x12 pack sauce bags</cbc:Description>
+        <cbc:Name>White sauce</cbc:Name>
+        <cac:SellersItemIdentification>
+          <cbc:ID>SN-34</cbc:ID>
+        </cac:SellersItemIdentification>
+        <cac:StandardItemIdentification>
+          <cbc:ID schemeID="0160">08722700575887</cbc:ID>
+        </cac:StandardItemIdentification>
+        <cac:ClassifiedTaxCategory>
+          <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:ClassifiedTaxCategory>
+        </cac:Item>
+    </cac:LineItem>
+  </cac:OrderLine>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>3</cbc:ID>
+      <cbc:Quantity unitCode="NAR" unitCodeListID="UNECERec20">15</cbc:Quantity>
+      <cbc:LineExtensionAmount currencyID="EUR">45</cbc:LineExtensionAmount>
+      <cbc:AccountingCost>MAFO-1</cbc:AccountingCost>
+      <cac:Price>
+        <cbc:PriceAmount currencyID="EUR">3</cbc:PriceAmount>
+      </cac:Price>
+       <cac:Item>
+        <cbc:Description>1x12 pack sauce bags</cbc:Description>
+        <cbc:Name>Pepper sauce</cbc:Name>
+        <cac:SellersItemIdentification>
+          <cbc:ID>SN-35</cbc:ID>
+        </cac:SellersItemIdentification>
+        <cac:StandardItemIdentification>
+          <cbc:ID schemeID="0160">08722700577584</cbc:ID>
+        </cac:StandardItemIdentification>
+        <cac:ClassifiedTaxCategory>
+          <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:ClassifiedTaxCategory>
+        </cac:Item>
+    </cac:LineItem>
+  </cac:OrderLine>
+</Order>

--- a/samples/order/use-cases/UC2_Order.xml
+++ b/samples/order/use-cases/UC2_Order.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Order xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Order-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:order_only:3</cbc:ProfileID>
+  <cbc:ID>1</cbc:ID>
+  <cbc:IssueDate>2013-07-01</cbc:IssueDate>
+  <cbc:IssueTime>14:15:20</cbc:IssueTime>
+   <cbc:DocumentCurrencyCode listID="ISO4217">EUR</cbc:DocumentCurrencyCode>
+  <cbc:AccountingCost>MAFO</cbc:AccountingCost>
+  <cac:ValidityPeriod>
+    <cbc:EndDate>2013-07-30</cbc:EndDate>
+  </cac:ValidityPeriod>
+  <cac:Contract>
+    <cbc:ID>C1</cbc:ID>
+  </cac:Contract>
+  <cac:BuyerCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">7300010000001</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>City Hospital</cbc:Name>
+      </cac:PartyName>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>City Hospital 345433</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0088">7300010000001</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:CityName>Eurocity</cbc:CityName>
+          <cac:Country>
+            <cbc:IdentificationCode listID="ISO3166-1:Alpha2">SE</cbc:IdentificationCode>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>Martin Foggerty</cbc:Name>
+        <cbc:Telephone>+46555785488</cbc:Telephone>
+        <cbc:ElectronicMail>martin.foggerty@cityhospital.se</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:BuyerCustomerParty>
+  <cac:SellerSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">7300010000001</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:StreetName>Harbour street</cbc:StreetName>
+        <cbc:AdditionalStreetName>Dock 45</cbc:AdditionalStreetName>
+        <cbc:CityName>Stockholm</cbc:CityName>
+        <cbc:PostalZone>50205</cbc:PostalZone>
+        <cbc:CountrySubentity>Region West</cbc:CountrySubentity>
+        <cac:AddressLine>
+          <cbc:Line>Gate 34</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>The Supplier AB</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:SellerSupplierParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Lower street 5</cbc:StreetName>
+        <cbc:AdditionalStreetName>Reception</cbc:AdditionalStreetName>
+        <cbc:CityName>Stockholm</cbc:CityName>
+        <cbc:PostalZone>11120</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">SE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+    <cac:RequestedDeliveryPeriod>
+      <cbc:StartDate>2013-07-15</cbc:StartDate>
+      <cbc:EndDate>2013-07-16</cbc:EndDate>
+    </cac:RequestedDeliveryPeriod>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>Hospital Tourist Department</cbc:Name>
+      </cac:PartyName>
+      <cac:Contact>
+        <cbc:Name>John</cbc:Name>
+        <cbc:Telephone>+465558877523</cbc:Telephone>
+        <cbc:ElectronicMail>john@cityhospital.se</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+   <cac:TaxTotal>
+		<cbc:TaxAmount currencyID="EUR">175.00</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:AnticipatedMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">700.00</cbc:LineExtensionAmount>
+    <cbc:PayableAmount currencyID="EUR">875.00</cbc:PayableAmount>
+  </cac:AnticipatedMonetaryTotal>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>1</cbc:ID>
+      <cbc:Quantity unitCode="NAR" unitCodeListID="UNECERec20">10</cbc:Quantity>
+      <cbc:LineExtensionAmount currencyID="EUR">400</cbc:LineExtensionAmount>
+      <cbc:AccountingCost>MAFO-1</cbc:AccountingCost>
+      <cac:Price>
+        <cbc:PriceAmount currencyID="EUR">40</cbc:PriceAmount>
+      </cac:Price>
+       <cac:Item>
+        <cbc:Description>Free text description of item 1</cbc:Description>
+        <cbc:Name>Item 1</cbc:Name>
+        <cac:ClassifiedTaxCategory>
+          <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:ClassifiedTaxCategory>
+        <cac:AdditionalItemProperty>
+			<cbc:Name>Color</cbc:Name>
+			<cbc:Value>Red</cbc:Value>
+        </cac:AdditionalItemProperty>
+        <cac:AdditionalItemProperty>
+			<cbc:Name>Size</cbc:Name>
+			<cbc:Value>43</cbc:Value>
+        </cac:AdditionalItemProperty>
+        </cac:Item>
+    </cac:LineItem>
+  </cac:OrderLine>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>2</cbc:ID>
+      <cbc:Quantity unitCode="NAR" unitCodeListID="UNECERec20">50</cbc:Quantity>
+      <cbc:LineExtensionAmount currencyID="EUR">300</cbc:LineExtensionAmount>
+      <cbc:AccountingCost>MAFO-1</cbc:AccountingCost>
+      <cac:Price>
+        <cbc:PriceAmount currencyID="EUR">6</cbc:PriceAmount>
+      </cac:Price>
+       <cac:Item>
+        <cbc:Description>Free text description of item 2</cbc:Description>
+        <cbc:Name>Item 2</cbc:Name>
+        <cac:ClassifiedTaxCategory>
+          <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:ClassifiedTaxCategory>
+        <cac:AdditionalItemProperty>
+			<cbc:Name>Color</cbc:Name>
+			<cbc:Value>Yellow</cbc:Value>
+        </cac:AdditionalItemProperty>
+        <cac:AdditionalItemProperty>
+			<cbc:Name>Size</cbc:Name>
+			<cbc:Value>36</cbc:Value>
+        </cac:AdditionalItemProperty>
+        </cac:Item>
+    </cac:LineItem>
+  </cac:OrderLine>
+  </Order>

--- a/samples/order/use-cases/UC3_Order.xml
+++ b/samples/order/use-cases/UC3_Order.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Order xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Order-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:order_only:3</cbc:ProfileID>
+  <cbc:ID>5</cbc:ID>
+  <cbc:IssueDate>2013-07-01</cbc:IssueDate>
+  <cbc:IssueTime>05:10:10</cbc:IssueTime>
+  <cbc:DocumentCurrencyCode listID="ISO4217">EUR</cbc:DocumentCurrencyCode>
+  <cbc:AccountingCost>MAFO</cbc:AccountingCost>
+  <cac:ValidityPeriod>
+    <cbc:EndDate>2013-07-30</cbc:EndDate>
+  </cac:ValidityPeriod>
+  <cac:Contract>
+    <cbc:ID>C1</cbc:ID>
+  </cac:Contract>
+  <cac:BuyerCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">7300010000001</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>City Hospital</cbc:Name>
+      </cac:PartyName>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>City Hospital 345433</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0088">7300010000001</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:CityName>Eurocity</cbc:CityName>
+          <cac:Country>
+            <cbc:IdentificationCode listID="ISO3166-1:Alpha2">SE</cbc:IdentificationCode>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>Martin Foggerty</cbc:Name>
+        <cbc:Telephone>+46555785488</cbc:Telephone>
+        <cbc:ElectronicMail>martin.foggerty@cityhospital.se</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:BuyerCustomerParty>
+  <cac:SellerSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0192">987654325</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0192">987654325</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:StreetName>Harbour street</cbc:StreetName>
+        <cbc:AdditionalStreetName>Dock 45</cbc:AdditionalStreetName>
+        <cbc:CityName>Bergen</cbc:CityName>
+        <cbc:PostalZone>5005</cbc:PostalZone>
+        <cbc:CountrySubentity>Region West</cbc:CountrySubentity>
+        <cac:AddressLine>
+          <cbc:Line>Gate 34</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode>NO</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Translation Services AS</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:SellerSupplierParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Lower street 5</cbc:StreetName>
+        <cbc:AdditionalStreetName>Reception</cbc:AdditionalStreetName>
+        <cbc:CityName>Oslo</cbc:CityName>
+        <cbc:PostalZone>11120</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">NO</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+    <cac:RequestedDeliveryPeriod>
+      <cbc:StartDate>2013-07-15</cbc:StartDate>
+      <cbc:EndDate>2013-07-16</cbc:EndDate>
+    </cac:RequestedDeliveryPeriod>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>Hospital Tourist Department</cbc:Name>
+      </cac:PartyName>
+      <cac:Contact>
+        <cbc:Name>John</cbc:Name>
+        <cbc:Telephone>+465558877523</cbc:Telephone>
+        <cbc:ElectronicMail>john@cityhospital.se</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:TaxTotal>
+	<cbc:TaxAmount currencyID="EUR">0</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:AnticipatedMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">400</cbc:LineExtensionAmount>
+    <cbc:PayableAmount currencyID="EUR">400</cbc:PayableAmount>
+  </cac:AnticipatedMonetaryTotal>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>1</cbc:ID>
+      <cbc:Quantity unitCode="DAY" unitCodeListID="UNECERec20">1</cbc:Quantity>
+      <cbc:LineExtensionAmount currencyID="EUR">400</cbc:LineExtensionAmount>
+      <cbc:AccountingCost>MAFO-1</cbc:AccountingCost>
+      <cac:Price>
+        <cbc:PriceAmount currencyID="EUR">400</cbc:PriceAmount>
+      </cac:Price>
+      <cac:Item>
+        <cbc:Description>Translation service Swedish - Spanish</cbc:Description>
+        <cbc:Name>Translation</cbc:Name>
+      </cac:Item>
+    </cac:LineItem>
+  </cac:OrderLine>
+</Order>

--- a/samples/order/use-cases/UC4_Order.xml
+++ b/samples/order/use-cases/UC4_Order.xml
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Order xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Order-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:order_only:3</cbc:ProfileID>
+  <cbc:ID>5</cbc:ID>
+  <cbc:IssueDate>2013-07-01</cbc:IssueDate>
+  <cbc:IssueTime>05:10:10</cbc:IssueTime>
+  <cbc:Note>Notes regarding the order</cbc:Note>
+  <cbc:DocumentCurrencyCode  listID="ISO4217">EUR</cbc:DocumentCurrencyCode>
+  <cbc:AccountingCost>MAFO</cbc:AccountingCost>
+  <cac:ValidityPeriod>
+    <cbc:EndDate>2013-07-30</cbc:EndDate>
+  </cac:ValidityPeriod>
+  <cac:QuotationDocumentReference>
+    <cbc:ID>55</cbc:ID>
+  </cac:QuotationDocumentReference>
+  <cac:OrderDocumentReference>
+    <cbc:ID>4</cbc:ID>
+  </cac:OrderDocumentReference>
+  <cac:OriginatorDocumentReference>
+    <cbc:ID>REQ-1</cbc:ID>
+  </cac:OriginatorDocumentReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>100</cbc:ID>
+    <cbc:DocumentType>Blueprint</cbc:DocumentType>
+    <cac:Attachment>
+          <cac:ExternalReference>
+        <cbc:URI>http://upload.wikimedia.org/wikipedia/commons/1/10/LaBelle_Blueprint.jpg</cbc:URI>
+      </cac:ExternalReference>
+    </cac:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:Contract>
+    <cbc:ID>C1</cbc:ID>
+  </cac:Contract>
+  <cac:BuyerCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0007">5541277711</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>City Hospital</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+		<cbc:StreetName>Main street 4</cbc:StreetName>
+        <cbc:AdditionalStreetName>Back door</cbc:AdditionalStreetName>
+        <cbc:CityName>Eurocity</cbc:CityName>
+        <cbc:PostalZone>11155</cbc:PostalZone>
+        <cbc:CountrySubentity>Region A</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">SE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="SE:ORGNR">SE554127771101</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>City Hospital 345433</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0088">7300010000001</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:CityName>Eurocity</cbc:CityName>
+          <cac:Country>
+            <cbc:IdentificationCode listID="ISO3166-1:Alpha2">SE</cbc:IdentificationCode>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>Martin Foggerty</cbc:Name>
+        <cbc:Telephone>+46555785488</cbc:Telephone>
+        <cbc:ElectronicMail>martin.foggerty@cityhospital.se</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:BuyerCustomerParty>
+  <cac:SellerSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0192">987654325</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0192">987654325</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:StreetName>Harbour street</cbc:StreetName>
+        <cbc:AdditionalStreetName>Dock 45</cbc:AdditionalStreetName>
+        <cbc:CityName>Bergen</cbc:CityName>
+        <cbc:PostalZone>5005</cbc:PostalZone>
+        <cbc:CountrySubentity>Region West</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">NO</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Cod Liver Oil Limited</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+       <cac:Contact>
+        <cbc:Name>Öystein</cbc:Name>
+        <cbc:Telephone>+47555444333</cbc:Telephone>
+        <cbc:ElectronicMail>oystein@codliveroil.no</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:SellerSupplierParty>
+  <cac:OriginatorCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Surgery Department</cbc:Name>
+      </cac:PartyName>
+      <cac:Contact>
+        <cbc:Name>Dr Bengt</cbc:Name>
+        <cbc:Telephone>+46555444777</cbc:Telephone>
+        <cbc:ElectronicMail>bengt@cityhospital.no</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:OriginatorCustomerParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0007">5544332211</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Swedish Hospitals</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>High Street 23</cbc:StreetName>
+        <cbc:AdditionalStreetName>First floor</cbc:AdditionalStreetName>
+        <cbc:CityName>Trondheim</cbc:CityName>
+        <cbc:PostalZone>7005</cbc:PostalZone>
+        <cbc:CountrySubentity>Region M</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">NO</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Swedish Hospitals AB</cbc:RegistrationName>
+        <cbc:CompanyID>5544332211</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:CityName>Stockholm</cbc:CityName>
+          <cac:Country>
+            <cbc:IdentificationCode listID="ISO3166-1:Alpha2">SE</cbc:IdentificationCode>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Lower street 5</cbc:StreetName>
+        <cbc:AdditionalStreetName>Docking gate 5</cbc:AdditionalStreetName>
+        <cbc:CityName>Stockholm</cbc:CityName>
+        <cbc:PostalZone>11120</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1:Alpha2">SE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+    <cac:RequestedDeliveryPeriod>
+      <cbc:StartDate>2013-07-15</cbc:StartDate>
+      <cbc:EndDate>2013-07-16</cbc:EndDate>
+    </cac:RequestedDeliveryPeriod>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Hospital Stock management</cbc:Name>
+      </cac:PartyName>
+      <cac:Contact>
+        <cbc:Name>John</cbc:Name>
+        <cbc:Telephone>+465558877523</cbc:Telephone>
+        <cbc:ElectronicMail>john@cityhospital.se</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:DeliveryTerms>
+    <cbc:ID schemeID="INCOTERMS">DAP</cbc:ID>
+    <cbc:SpecialTerms>These special terms applies to the delivery...</cbc:SpecialTerms>
+    <cac:DeliveryLocation>
+      <cbc:ID>schemeID="GLN">7054673128432</cbc:ID>
+    </cac:DeliveryLocation>
+  </cac:DeliveryTerms>
+  <cac:AllowanceCharge>
+    <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+    <cbc:AllowanceChargeReason>Freight cost</cbc:AllowanceChargeReason>
+    <cbc:Amount currencyID="EUR">10</cbc:Amount>
+  </cac:AllowanceCharge>
+  <cac:AllowanceCharge>
+    <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+    <cbc:AllowanceChargeReason>Agreed discount</cbc:AllowanceChargeReason>
+    <cbc:Amount currencyID="EUR">10</cbc:Amount>
+  </cac:AllowanceCharge>
+    <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">5</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:AnticipatedMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">50</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">50</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">55</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="EUR">10</cbc:AllowanceTotalAmount>
+    <cbc:ChargeTotalAmount currencyID="EUR">10</cbc:ChargeTotalAmount>
+    <cbc:PayableRoundingAmount currencyID="EUR">0</cbc:PayableRoundingAmount>
+    <cbc:PayableAmount currencyID="EUR">55</cbc:PayableAmount>
+  </cac:AnticipatedMonetaryTotal>
+  <cac:OrderLine>
+    <cbc:Note>This free text note can be used....</cbc:Note>
+    <cac:LineItem>
+      <cbc:ID>1</cbc:ID>
+      <cbc:Quantity unitCode="NAR" unitCodeListID="UNECERec20">50</cbc:Quantity>
+      <cbc:LineExtensionAmount currencyID="EUR">50</cbc:LineExtensionAmount>
+      <cbc:PartialDeliveryIndicator>true</cbc:PartialDeliveryIndicator>
+      <cbc:AccountingCost>MAFO-1</cbc:AccountingCost>
+      <cac:Delivery>
+        <cac:RequestedDeliveryPeriod>
+          <cbc:StartDate>2013-07-15</cbc:StartDate>
+          <cbc:EndDate>2013-07-16</cbc:EndDate>
+        </cac:RequestedDeliveryPeriod>
+      </cac:Delivery>
+      <cac:OriginatorParty>
+       <cac:PartyIdentification>
+         <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+        </cac:PartyIdentification>
+        <cac:PartyName>
+          <cbc:Name>Martin</cbc:Name>
+        </cac:PartyName>
+      </cac:OriginatorParty>
+      <cac:Price>
+        <cbc:PriceAmount currencyID="EUR">1</cbc:PriceAmount>
+        <cbc:BaseQuantity unitCode="NAR" unitCodeListID="UNECERec20">1</cbc:BaseQuantity>
+        <cac:AllowanceCharge>
+          <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+          <cbc:Amount currencyID="EUR">1</cbc:Amount>
+          <cbc:BaseAmount currencyID="EUR">2</cbc:BaseAmount>
+        </cac:AllowanceCharge>
+      </cac:Price>
+      <cac:Item>
+        <cbc:Description>Aluminium snow shovel with left-handed grip</cbc:Description>
+        <cbc:Name>Snow shovel</cbc:Name>
+        <cac:SellersItemIdentification>
+          <cbc:ID>SN-33</cbc:ID>
+        </cac:SellersItemIdentification>
+        <cac:StandardItemIdentification>
+          <cbc:ID schemeID="0160">09876543211234</cbc:ID>
+        </cac:StandardItemIdentification>
+        <cac:CommodityClassification>
+          <cbc:ItemClassificationCode listID="MP">76455</cbc:ItemClassificationCode>
+        </cac:CommodityClassification>
+        <cac:ClassifiedTaxCategory>
+          <cbc:ID  schemeID="UNCL5305">S</cbc:ID>
+          <cbc:Percent>10</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:ClassifiedTaxCategory>
+        <cac:AdditionalItemProperty>
+          <cbc:Name>GRIP</cbc:Name>
+          <cbc:Value>Left-handed</cbc:Value>
+        </cac:AdditionalItemProperty>
+        <cac:AdditionalItemProperty>
+          <cbc:Name>Purpose</cbc:Name>
+          <cbc:Value>Snow</cbc:Value>
+        </cac:AdditionalItemProperty>
+      </cac:Item>
+    </cac:LineItem>
+  </cac:OrderLine>
+</Order>

--- a/samples/order/use-cases/UC5_Order.xml
+++ b/samples/order/use-cases/UC5_Order.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns="urn:oasis:names:specification:ubl:schema:xsd:Order-2"
+ xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+ xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+ xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:ordering:3</cbc:ProfileID>
+  <cbc:ID>5</cbc:ID>
+  <cbc:IssueDate>2019-09-30</cbc:IssueDate>
+  <cbc:IssueTime>05:10:10</cbc:IssueTime>
+   <cbc:DocumentCurrencyCode listID="ISO4217">SEK</cbc:DocumentCurrencyCode>
+  <cbc:AccountingCost>MAFO</cbc:AccountingCost>
+  <cac:ValidityPeriod>
+    <cbc:EndDate>2019-10-02</cbc:EndDate>
+  </cac:ValidityPeriod>
+  <cac:Contract>
+    <cbc:ID>C1</cbc:ID>
+  </cac:Contract>
+  <cac:BuyerCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0007">2041277711</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0007">2041277711</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Region West</cbc:Name>
+      </cac:PartyName>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Region West</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0007">2041277711</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:CityName>Göteborg</cbc:CityName>
+          <cac:Country>
+            <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:BuyerCustomerParty>
+  <cac:SellerSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0007">5546577799</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0007">5546577799</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Supplier AB</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Godsgatan 2</cbc:StreetName>
+        <cbc:CityName>Borås</cbc:CityName>
+        <cbc:PostalZone>40539</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Supplier AB</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:SellerSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">7351233370051</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7351233370051</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Southern Hospital</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Borås</cbc:CityName>
+        <cbc:PostalZone>40300</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Southern Hospital</cbc:RegistrationName>
+        <cbc:CompanyID>2041277711</cbc:CompanyID>
+        <cac:RegistrationAddress>
+          <cbc:CityName>Borås</cbc:CityName>
+          <cac:Country>
+            <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+          </cac:Country>
+        </cac:RegistrationAddress>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cbc:ID schemeID="0088">73512333000108</cbc:ID>
+      <cbc:Name>Southern Hospital</cbc:Name>
+      <cac:Address>
+        <cbc:StreetName>Sjukhusgatan 14</cbc:StreetName>
+        <cbc:AdditionalStreetName>Godsmottagningen</cbc:AdditionalStreetName>
+        <cbc:CityName>Borås</cbc:CityName>
+        <cbc:PostalZone>40355</cbc:PostalZone>
+        <cac:AddressLine>
+          <cbc:Line>Portkod 1234</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+    <cac:RequestedDeliveryPeriod>
+      <cbc:StartDate>2019-10-15</cbc:StartDate>
+      <cbc:EndDate>2019-10-16</cbc:EndDate>
+    </cac:RequestedDeliveryPeriod>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">73512333000115</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Southern Hospital</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Sjukhusgatan 16</cbc:StreetName>
+        <cbc:AdditionalStreetName>Surgical unit</cbc:AdditionalStreetName>
+        <cbc:CityName>Borås</cbc:CityName>
+        <cbc:PostalZone>40355</cbc:PostalZone>
+        <cac:AddressLine>
+          <cbc:Line>Ingång 1, Skylt F</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode>SE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:Contact>
+        <cbc:Name>John Johnsson</cbc:Name>
+        <cbc:Telephone>+463158877523</cbc:Telephone>
+        <cbc:ElectronicMail>john.johnsson@westregion.se</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:TaxTotal>
+		<cbc:TaxAmount currencyID="SEK">28.75</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:AnticipatedMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="SEK">115</cbc:LineExtensionAmount>
+    <cbc:PayableAmount currencyID="SEK">143.75</cbc:PayableAmount>
+  </cac:AnticipatedMonetaryTotal>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>1</cbc:ID>
+      <cbc:Quantity unitCode="EA" unitCodeListID="UNECERec20">10</cbc:Quantity>
+      <cbc:LineExtensionAmount currencyID="SEK">40</cbc:LineExtensionAmount>
+      <cac:Price>
+        <cbc:PriceAmount currencyID="SEK">4</cbc:PriceAmount>
+      </cac:Price>
+       <cac:Item>
+        <cbc:Name>1x12 pack waste bags 1 lit</cbc:Name>
+        <cac:SellersItemIdentification>
+          <cbc:ID>11111</cbc:ID>
+        </cac:SellersItemIdentification>
+        <cac:ClassifiedTaxCategory>
+          <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:ClassifiedTaxCategory>
+        </cac:Item>
+    </cac:LineItem>
+  </cac:OrderLine>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>2</cbc:ID>
+      <cbc:Quantity unitCode="EA" unitCodeListID="UNECERec20">5</cbc:Quantity>
+      <cbc:LineExtensionAmount currencyID="SEK">30</cbc:LineExtensionAmount>
+      <cac:Price>
+        <cbc:PriceAmount currencyID="SEK">6</cbc:PriceAmount>
+      </cac:Price>
+       <cac:Item>
+         <cbc:Name>Waste bags 2,5 lit</cbc:Name>
+        <cac:SellersItemIdentification>
+          <cbc:ID>111125</cbc:ID>
+        </cac:SellersItemIdentification>
+        <cac:ClassifiedTaxCategory>
+          <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:ClassifiedTaxCategory>
+        </cac:Item>
+    </cac:LineItem>
+  </cac:OrderLine>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>3</cbc:ID>
+      <cbc:Quantity unitCode="EA" unitCodeListID="UNECERec20">15</cbc:Quantity>
+      <cbc:LineExtensionAmount currencyID="SEK">45</cbc:LineExtensionAmount>
+      <cac:Price>
+        <cbc:PriceAmount currencyID="SEK">3</cbc:PriceAmount>
+      </cac:Price>
+       <cac:Item>
+         <cbc:Name>Black Plastic bags 25 lit</cbc:Name>
+        <cac:SellersItemIdentification>
+          <cbc:ID>11135</cbc:ID>
+        </cac:SellersItemIdentification>
+        <cac:ClassifiedTaxCategory>
+          <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:ClassifiedTaxCategory>
+        </cac:Item>
+    </cac:LineItem>
+  </cac:OrderLine>
+</Order>


### PR DESCRIPTION
- Add 5 Order use case XML examples demonstrating different scenarios:
  * UC1_Order through UC5_Order
- Include complete PEPPOL BIS Order structure with:
  * Buyer and seller party information
  * Delivery details
  * Tax and monetary totals
  * Line item details