### PR TITLE
feat: Add Order Response examples and use cases

### DIFF
--- a/samples/order-response/basic/OrderResponse_Example.xml
+++ b/samples/order-response/basic/OrderResponse_Example.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<OrderResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:OrderResponse-2"
+			   xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+			   xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+	<cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order_response:3</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:ordering:3</cbc:ProfileID>
+	<cbc:ID>101</cbc:ID>
+	<cbc:SalesOrderID>101-111</cbc:SalesOrderID>
+	<cbc:IssueDate>2013-07-01</cbc:IssueDate>
+	<cbc:IssueTime>06:10:10</cbc:IssueTime>
+	<cbc:OrderResponseCode>AP</cbc:OrderResponseCode>
+	<cbc:Note>Response message with amendments in the details</cbc:Note>
+	<cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+	<cbc:CustomerReference>ABC-123</cbc:CustomerReference>
+	<cac:OrderReference>
+		<cbc:ID>11233</cbc:ID>
+	</cac:OrderReference>
+	<cac:SellerSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0088">7598000000128</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0184">DK12345678</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>The Supplier AB</cbc:RegistrationName>
+			</cac:PartyLegalEntity>
+		</cac:Party>
+	</cac:SellerSupplierParty>
+	<cac:BuyerCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0088">7590000012347</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0184">DK55412777</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>City Hospital</cbc:RegistrationName>
+			</cac:PartyLegalEntity>
+		</cac:Party>
+	</cac:BuyerCustomerParty>
+	<cac:Delivery>
+		<cac:PromisedDeliveryPeriod>
+			<cbc:StartDate>2013-07-15</cbc:StartDate>
+			<cbc:StartTime>12:30:00</cbc:StartTime>
+			<cbc:EndDate>2013-07-16</cbc:EndDate>
+			<cbc:EndTime>18:00:00</cbc:EndTime>
+		</cac:PromisedDeliveryPeriod>
+	</cac:Delivery>
+	<cac:OrderLine>
+		<cac:LineItem>
+			<cbc:ID>1</cbc:ID>
+			<cbc:Note>Order line note text</cbc:Note>
+			<cbc:LineStatusCode>3</cbc:LineStatusCode>
+			<cbc:Quantity unitCode="C62">10</cbc:Quantity>
+			<cbc:MaximumBackorderQuantity>3</cbc:MaximumBackorderQuantity>
+			<cac:Delivery>
+				<cac:PromisedDeliveryPeriod>
+					<cbc:StartDate>2018-08-10</cbc:StartDate>
+					<cbc:EndDate>2018-08-12</cbc:EndDate>
+				</cac:PromisedDeliveryPeriod>
+			</cac:Delivery>
+			<cac:Price>
+				<cbc:PriceAmount currencyID="EUR">1.50</cbc:PriceAmount>
+				<cbc:BaseQuantity unitCode="C62">1</cbc:BaseQuantity>
+			</cac:Price>
+			<cac:Item>
+				<cbc:Name>Brown sauce</cbc:Name>
+				<cac:BuyersItemIdentification>
+					<cbc:ID>123456</cbc:ID>
+				</cac:BuyersItemIdentification>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-33</cbc:ID>
+				</cac:SellersItemIdentification>
+				<cac:StandardItemIdentification>
+					<cbc:ID schemeID="0160">7400000001234</cbc:ID>
+				</cac:StandardItemIdentification>
+			</cac:Item>
+		</cac:LineItem>
+		<cac:SellerSubstitutedLineItem>
+			<cbc:ID>12356</cbc:ID>
+			<cac:Item>
+				<cbc:Name>Sauce brown, ready</cbc:Name>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-34</cbc:ID>
+				</cac:SellersItemIdentification>
+				<cac:StandardItemIdentification>
+					<cbc:ID schemeID="0160">7400000001235</cbc:ID>
+				</cac:StandardItemIdentification>
+				<cac:CommodityClassification>
+					<cbc:ItemClassificationCode listID="MP" listVersionID="19.0501">12345678</cbc:ItemClassificationCode>
+				</cac:CommodityClassification>
+				<cac:ClassifiedTaxCategory>
+					<cbc:ID>S</cbc:ID>
+					<cbc:Percent>25</cbc:Percent>
+					<cac:TaxScheme>
+						<cbc:ID>VAT</cbc:ID>
+					</cac:TaxScheme>
+				</cac:ClassifiedTaxCategory>
+				<cac:AdditionalItemProperty>
+					<cbc:Name>Weight</cbc:Name>
+					<cbc:Value>12 gram</cbc:Value>
+					<cbc:ValueQuantity unitCode="GRM">12</cbc:ValueQuantity>
+					<cbc:ValueQualifier>gram</cbc:ValueQualifier>
+				</cac:AdditionalItemProperty>
+			</cac:Item>
+		</cac:SellerSubstitutedLineItem>
+		<cac:OrderLineReference>
+			<cbc:LineID>1</cbc:LineID>
+		</cac:OrderLineReference>
+	</cac:OrderLine>
+	<cac:OrderLine>
+		<cac:LineItem>
+			<cbc:ID>2</cbc:ID>
+			<cbc:LineStatusCode>5</cbc:LineStatusCode>
+			<cac:Item>
+				<cbc:Name>White sauce</cbc:Name>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-34</cbc:ID>
+				</cac:SellersItemIdentification>
+			</cac:Item>
+		</cac:LineItem>
+		<cac:OrderLineReference>
+			<cbc:LineID>2</cbc:LineID>
+		</cac:OrderLineReference>
+	</cac:OrderLine>
+	<cac:OrderLine>
+		<cac:LineItem>
+			<cbc:ID>3</cbc:ID>
+			<cbc:Note>Substituted Item</cbc:Note>
+			<cbc:LineStatusCode>3</cbc:LineStatusCode>
+			<cac:Item>
+				<cbc:Name>Pepper sauce</cbc:Name>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-35</cbc:ID>
+				</cac:SellersItemIdentification>
+			</cac:Item>
+		</cac:LineItem>
+		<cac:SellerSubstitutedLineItem>
+			<cbc:ID>1</cbc:ID>
+			<cac:Item>
+				<cbc:Name>Pepper sauce</cbc:Name>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-36</cbc:ID>
+				</cac:SellersItemIdentification>
+				<cac:StandardItemIdentification>
+					<cbc:ID schemeID="0160">8722700577588</cbc:ID>
+				</cac:StandardItemIdentification>
+				<cac:ClassifiedTaxCategory>
+					<cbc:ID>S</cbc:ID>
+					<cbc:Percent>25</cbc:Percent>
+					<cac:TaxScheme>
+						<cbc:ID>VAT</cbc:ID>
+					</cac:TaxScheme>
+				</cac:ClassifiedTaxCategory>
+			</cac:Item>
+		</cac:SellerSubstitutedLineItem>
+		<cac:OrderLineReference>
+			<cbc:LineID>3</cbc:LineID>
+		</cac:OrderLineReference>
+	</cac:OrderLine>
+</OrderResponse>

--- a/samples/order-response/basic/SG OrderResponse_Example.xml
+++ b/samples/order-response/basic/SG OrderResponse_Example.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<OrderResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:OrderResponse-2"
+			   xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+			   xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+	<cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order_response:3</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:ordering:3</cbc:ProfileID>
+	<cbc:ID>101</cbc:ID>
+	<cbc:SalesOrderID>101-111</cbc:SalesOrderID>
+	<cbc:IssueDate>2013-07-01</cbc:IssueDate>
+	<cbc:IssueTime>06:10:10</cbc:IssueTime>
+	<cbc:OrderResponseCode>AP</cbc:OrderResponseCode>
+	<cbc:Note>Response message with amendments in the details</cbc:Note>
+	<cbc:DocumentCurrencyCode>SGD</cbc:DocumentCurrencyCode>
+	<cbc:CustomerReference>ABC-123</cbc:CustomerReference>
+	<cac:OrderReference>
+		<cbc:ID>11233</cbc:ID>
+	</cac:OrderReference>
+	<cac:SellerSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0195">SGUEN200212345Z</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>SG12345678</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>The Supplier AB</cbc:RegistrationName>
+			</cac:PartyLegalEntity>
+		</cac:Party>
+	</cac:SellerSupplierParty>
+	<cac:BuyerCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0195">SGUEN200254321Z</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>6513954</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>City Hospital</cbc:RegistrationName>
+			</cac:PartyLegalEntity>
+		</cac:Party>
+	</cac:BuyerCustomerParty>
+	<cac:Delivery>
+		<cac:PromisedDeliveryPeriod>
+			<cbc:StartDate>2013-07-15</cbc:StartDate>
+			<cbc:EndDate>2013-07-16</cbc:EndDate>
+		</cac:PromisedDeliveryPeriod>
+	</cac:Delivery>
+	<cac:OrderLine>
+		<cac:LineItem>
+			<cbc:ID>1</cbc:ID>
+			<cbc:Note>Order line note text</cbc:Note>
+			<cbc:LineStatusCode>3</cbc:LineStatusCode>
+			<cbc:Quantity unitCode="C62">10</cbc:Quantity>
+			<cbc:MaximumBackorderQuantity>3</cbc:MaximumBackorderQuantity>
+			<cac:Delivery>
+				<cac:PromisedDeliveryPeriod>
+					<cbc:StartDate>2018-08-10</cbc:StartDate>
+					<cbc:EndDate>2018-08-12</cbc:EndDate>
+				</cac:PromisedDeliveryPeriod>
+			</cac:Delivery>
+			<cac:Price>
+				<cbc:PriceAmount currencyID="SGD">1.50</cbc:PriceAmount>
+				<cbc:BaseQuantity unitCode="C62">1</cbc:BaseQuantity>
+			</cac:Price>
+			<cac:Item>
+				<cbc:Name>Brown sauce</cbc:Name>
+				<cac:BuyersItemIdentification>
+					<cbc:ID>123456</cbc:ID>
+				</cac:BuyersItemIdentification>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-33</cbc:ID>
+				</cac:SellersItemIdentification>
+				<cac:StandardItemIdentification>
+					<cbc:ID schemeID="0160">7400000001234</cbc:ID>
+				</cac:StandardItemIdentification>
+			</cac:Item>
+		</cac:LineItem>
+		<cac:SellerSubstitutedLineItem>
+			<cbc:ID>12356</cbc:ID>
+			<cac:Item>
+				<cbc:Name>Sauce brown, ready</cbc:Name>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-34</cbc:ID>
+				</cac:SellersItemIdentification>
+				<cac:StandardItemIdentification>
+					<cbc:ID schemeID="0160">7400000001235</cbc:ID>
+				</cac:StandardItemIdentification>
+				<cac:CommodityClassification>
+					<cbc:ItemClassificationCode listID="MP" listVersionID="19.0501">12345678</cbc:ItemClassificationCode>
+				</cac:CommodityClassification>
+				<cac:ClassifiedTaxCategory>
+					<cbc:ID>SR</cbc:ID>
+					<cbc:Percent>7</cbc:Percent>
+					<cac:TaxScheme>
+						<cbc:ID>GST</cbc:ID>
+					</cac:TaxScheme>
+				</cac:ClassifiedTaxCategory>
+				<cac:AdditionalItemProperty>
+					<cbc:Name>Weight</cbc:Name>
+					<cbc:Value>12 gram</cbc:Value>
+					<cbc:ValueQuantity unitCode="GRM">12</cbc:ValueQuantity>
+					<cbc:ValueQualifier>gram</cbc:ValueQualifier>
+				</cac:AdditionalItemProperty>
+			</cac:Item>
+		</cac:SellerSubstitutedLineItem>
+		<cac:OrderLineReference>
+			<cbc:LineID>1</cbc:LineID>
+		</cac:OrderLineReference>
+	</cac:OrderLine>
+	<cac:OrderLine>
+		<cac:LineItem>
+			<cbc:ID>2</cbc:ID>
+			<cbc:LineStatusCode>5</cbc:LineStatusCode>
+			<cac:Item>
+				<cbc:Name>White sauce</cbc:Name>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-34</cbc:ID>
+				</cac:SellersItemIdentification>
+			</cac:Item>
+		</cac:LineItem>
+		<cac:OrderLineReference>
+			<cbc:LineID>2</cbc:LineID>
+		</cac:OrderLineReference>
+	</cac:OrderLine>
+	<cac:OrderLine>
+		<cac:LineItem>
+			<cbc:ID>3</cbc:ID>
+			<cbc:Note>Substituted Item</cbc:Note>
+			<cbc:LineStatusCode>3</cbc:LineStatusCode>
+			<cac:Item>
+				<cbc:Name>Pepper sauce</cbc:Name>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-35</cbc:ID>
+				</cac:SellersItemIdentification>
+			</cac:Item>
+		</cac:LineItem>
+		<cac:SellerSubstitutedLineItem>
+			<cbc:ID>1</cbc:ID>
+			<cac:Item>
+				<cbc:Name>Pepper sauce</cbc:Name>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-36</cbc:ID>
+				</cac:SellersItemIdentification>
+				<cac:StandardItemIdentification>
+					<cbc:ID schemeID="0160">8722700577588</cbc:ID>
+				</cac:StandardItemIdentification>
+				<cac:ClassifiedTaxCategory>
+					<cbc:ID>SR</cbc:ID>
+					<cbc:Percent>7</cbc:Percent>
+					<cac:TaxScheme>
+						<cbc:ID>GST</cbc:ID>
+					</cac:TaxScheme>
+				</cac:ClassifiedTaxCategory>
+			</cac:Item>
+		</cac:SellerSubstitutedLineItem>
+		<cac:OrderLineReference>
+			<cbc:LineID>3</cbc:LineID>
+		</cac:OrderLineReference>
+	</cac:OrderLine>
+</OrderResponse>

--- a/samples/order-response/use-cases/UC1_Order_response.xml
+++ b/samples/order-response/use-cases/UC1_Order_response.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OrderResponse xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:OrderResponse-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order_response:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:ordering:3</cbc:ProfileID>
+  <cbc:ID>101</cbc:ID>
+  <cbc:IssueDate>2013-07-01</cbc:IssueDate>
+  <cbc:IssueTime>06:10:10</cbc:IssueTime>
+  <cbc:OrderResponseCode>CA</cbc:OrderResponseCode>
+  <cbc:Note>Response message with amendments in the details</cbc:Note>
+  <cbc:DocumentCurrencyCode listID="ISO4217">EUR</cbc:DocumentCurrencyCode>
+  <cbc:CustomerReference>Your ref</cbc:CustomerReference>
+  <cac:OrderReference>
+    <cbc:ID>1</cbc:ID>
+  </cac:OrderReference>
+  <cac:SellerSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">7300010000001</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>The Supplier AB</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:SellerSupplierParty>
+   <cac:BuyerCustomerParty>
+     <cac:Party>
+     <cbc:EndpointID schemeID="0088">7300010000001</cbc:EndpointID>
+     <cac:PartyIdentification>
+       <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+    </cac:Party>
+  </cac:BuyerCustomerParty>
+  <cac:Delivery>
+    <cac:PromisedDeliveryPeriod>
+      <cbc:StartDate>2013-07-15</cbc:StartDate>
+      <cbc:EndDate>2013-07-16</cbc:EndDate>
+    </cac:PromisedDeliveryPeriod>
+  </cac:Delivery>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>1</cbc:ID>
+      <cbc:LineStatusCode>5</cbc:LineStatusCode>
+	  <cac:Item>
+			<cbc:Name>Brown sauce</cbc:Name>
+			<cac:SellersItemIdentification>
+			  <cbc:ID>SN-33</cbc:ID>
+			</cac:SellersItemIdentification>
+		</cac:Item>		
+      </cac:LineItem>
+      <cac:OrderLineReference>
+		  <cbc:LineID>1</cbc:LineID>
+      </cac:OrderLineReference>
+  </cac:OrderLine> 
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>2</cbc:ID>
+      <cbc:LineStatusCode>7</cbc:LineStatusCode>
+      <cac:Item>
+			<cbc:Name>White sauce</cbc:Name>
+			<cac:SellersItemIdentification>
+			  <cbc:ID>SN-34</cbc:ID>
+			</cac:SellersItemIdentification>
+		</cac:Item>		
+      </cac:LineItem>
+      <cac:OrderLineReference>
+		  <cbc:LineID>2</cbc:LineID>
+      </cac:OrderLineReference>
+  </cac:OrderLine> 
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>3</cbc:ID>
+      <cbc:Note>Substituted Item</cbc:Note>
+      <cbc:LineStatusCode>3</cbc:LineStatusCode>
+      <cac:Item>
+			<cbc:Name>Pepper sauce</cbc:Name>
+			<cac:SellersItemIdentification>
+			  <cbc:ID>SN-35</cbc:ID>
+			</cac:SellersItemIdentification>
+		</cac:Item>		
+    </cac:LineItem>
+		<cac:SellerSubstitutedLineItem>
+		  <cbc:ID>1</cbc:ID>
+		  <cac:Item>
+			<cbc:Name>Pepper sauce</cbc:Name>
+			<cac:SellersItemIdentification>
+			  <cbc:ID>SN-36</cbc:ID>
+			</cac:SellersItemIdentification>
+			<cac:StandardItemIdentification>
+			  <cbc:ID schemeID="0160">8722700577588</cbc:ID>
+			</cac:StandardItemIdentification>
+			<cac:ClassifiedTaxCategory>
+			  <cbc:ID schemeID="UNCL5305">S</cbc:ID>
+				  <cbc:Percent>25</cbc:Percent>
+			  <cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+			  </cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+			</cac:Item>
+		</cac:SellerSubstitutedLineItem>
+	<cac:OrderLineReference>
+      <cbc:LineID>3</cbc:LineID>
+    </cac:OrderLineReference>
+  </cac:OrderLine>
+</OrderResponse>

--- a/samples/order-response/use-cases/UC2_Order_response.xml
+++ b/samples/order-response/use-cases/UC2_Order_response.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OrderResponse xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:OrderResponse-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order_response:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:ordering:3</cbc:ProfileID>
+  <cbc:ID>101</cbc:ID>
+  <cbc:IssueDate>2013-07-01</cbc:IssueDate>
+  <cbc:IssueTime>14:23:26</cbc:IssueTime>
+  <cbc:OrderResponseCode>AP</cbc:OrderResponseCode>
+  <cbc:Note>Response message with item identifiers</cbc:Note>
+  <cbc:DocumentCurrencyCode listID="ISO4217">EUR</cbc:DocumentCurrencyCode>
+  <cbc:CustomerReference>92487ksdhfj</cbc:CustomerReference>
+  <cac:OrderReference>
+    <cbc:ID>1</cbc:ID>
+  </cac:OrderReference>
+  <cac:SellerSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID  schemeID="0088">7300010000001</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+    </cac:Party>
+  </cac:SellerSupplierParty>
+   <cac:BuyerCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0192">987654325</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0192">987654325</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>City Hospital</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:BuyerCustomerParty>
+  <cac:Delivery>
+    <cac:PromisedDeliveryPeriod>
+      <cbc:StartDate>2013-07-15</cbc:StartDate>
+      <cbc:EndDate>2013-07-16</cbc:EndDate>
+    </cac:PromisedDeliveryPeriod>
+  </cac:Delivery>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>1</cbc:ID>
+      <cbc:LineStatusCode>5</cbc:LineStatusCode>
+	  <cac:Item>
+			<cbc:Name>Item 1, color red, size 43</cbc:Name>
+			<cac:SellersItemIdentification>
+			  <cbc:ID>4545423</cbc:ID>
+			</cac:SellersItemIdentification>
+			<cac:StandardItemIdentification>
+			  <cbc:ID schemeID="0160">05432167890984</cbc:ID>
+			</cac:StandardItemIdentification>
+		</cac:Item>
+      </cac:LineItem>
+      <cac:OrderLineReference>
+		  <cbc:LineID>1</cbc:LineID>
+      </cac:OrderLineReference>
+  </cac:OrderLine>
+  <cac:OrderLine>
+    <cac:LineItem>
+      <cbc:ID>2</cbc:ID>
+      <cbc:LineStatusCode>5</cbc:LineStatusCode>
+      <cac:Item>
+			<cbc:Name>Item 2, color yellow, size 36</cbc:Name>
+			<cac:SellersItemIdentification>
+			  <cbc:ID>64534543</cbc:ID>
+			</cac:SellersItemIdentification>
+			<cac:StandardItemIdentification>
+			  <cbc:ID schemeID="0160">05476154389097</cbc:ID>
+			</cac:StandardItemIdentification>
+		</cac:Item>
+      </cac:LineItem>
+      <cac:OrderLineReference>
+		  <cbc:LineID>2</cbc:LineID>
+      </cac:OrderLineReference>
+  </cac:OrderLine>
+  </OrderResponse>

--- a/samples/order-response/use-cases/UC3_Order_response.xml
+++ b/samples/order-response/use-cases/UC3_Order_response.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OrderResponse xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:OrderResponse-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order_response:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:ordering:3</cbc:ProfileID>
+  <cbc:ID>4552</cbc:ID>
+  <cbc:IssueDate>2013-07-01</cbc:IssueDate>
+  <cbc:IssueTime>06:10:10</cbc:IssueTime>
+  <cbc:OrderResponseCode>RE</cbc:OrderResponseCode>
+  <cbc:Note>No available translators</cbc:Note>
+  <cbc:DocumentCurrencyCode listID="ISO4217">EUR</cbc:DocumentCurrencyCode>
+  <cbc:CustomerReference>123abc</cbc:CustomerReference>
+  <cac:OrderReference>
+    <cbc:ID>5</cbc:ID>
+  </cac:OrderReference>
+  <cac:SellerSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0192">987654325</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0192">987654325</cbc:ID>
+      </cac:PartyIdentification>
+    </cac:Party>
+  </cac:SellerSupplierParty>
+  <cac:BuyerCustomerParty>
+      <cac:Party>
+        <cbc:EndpointID schemeID="0088">7300010000001</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID  schemeID="0088">7300010000001</cbc:ID>
+      </cac:PartyIdentification>
+    </cac:Party>
+  </cac:BuyerCustomerParty>
+  </OrderResponse>

--- a/samples/order-response/use-cases/UC4_Order_response.xml
+++ b/samples/order-response/use-cases/UC4_Order_response.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OrderResponse xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:oasis:names:specification:ubl:schema:xsd:OrderResponse-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+	<cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order_response:3</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:ordering:3</cbc:ProfileID>
+	<cbc:ID>4552</cbc:ID>
+	<cbc:IssueDate>2013-07-01</cbc:IssueDate>
+	<cbc:IssueTime>06:10:10</cbc:IssueTime>
+	<cbc:OrderResponseCode>CA</cbc:OrderResponseCode>
+	<cbc:Note>Response message with amendments in the details</cbc:Note>
+	<cbc:DocumentCurrencyCode listID="ISO4217">EUR</cbc:DocumentCurrencyCode>
+	<cbc:CustomerReference>Your ref</cbc:CustomerReference>
+	<cac:OrderReference>
+		<cbc:ID>5</cbc:ID>
+	</cac:OrderReference>
+	<cac:SellerSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0192">987654325</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0192">987654325</cbc:ID>
+			</cac:PartyIdentification>
+		</cac:Party>
+	</cac:SellerSupplierParty>
+	<cac:BuyerCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0088">7300010000001</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID schemeID="0088">7300010000001</cbc:ID>
+			</cac:PartyIdentification>
+		</cac:Party>
+	</cac:BuyerCustomerParty>
+	<cac:Delivery>
+		<cac:PromisedDeliveryPeriod>
+			<cbc:StartDate>2013-07-15</cbc:StartDate>
+			<cbc:EndDate>2013-07-16</cbc:EndDate>
+		</cac:PromisedDeliveryPeriod>
+	</cac:Delivery>
+	<cac:OrderLine>
+		<cac:LineItem>
+			<cbc:ID>1</cbc:ID>
+			<cbc:Note>with changes (price)</cbc:Note>
+			<cbc:LineStatusCode>3</cbc:LineStatusCode>
+			<cbc:Quantity unitCode="NAR" unitCodeListID="UNECERec20">500</cbc:Quantity>
+			<cac:Delivery>
+				<cac:PromisedDeliveryPeriod>
+					<cbc:StartDate>2013-07-15</cbc:StartDate>
+					<cbc:EndDate>2013-07-16</cbc:EndDate>
+				</cac:PromisedDeliveryPeriod>
+			</cac:Delivery>
+			<cac:Price>
+				<cbc:PriceAmount currencyID="EUR" >0.9</cbc:PriceAmount>
+				<cbc:BaseQuantity unitCode="NAR" unitCodeListID="UNECERec20">10</cbc:BaseQuantity>
+			</cac:Price>
+			<cac:Item>
+				<cbc:Name>Snow shovel</cbc:Name>
+				<cac:SellersItemIdentification>
+					<cbc:ID>SN-33</cbc:ID>
+				</cac:SellersItemIdentification>
+				<cac:StandardItemIdentification>
+					<cbc:ID schemeID="0160">09876543211234</cbc:ID>
+				</cac:StandardItemIdentification>
+			</cac:Item>
+		</cac:LineItem>
+		<cac:OrderLineReference>
+			<cbc:LineID>1</cbc:LineID>
+		</cac:OrderLineReference>
+	</cac:OrderLine>
+</OrderResponse>

--- a/samples/order-response/use-cases/UC5_Order_response.xml
+++ b/samples/order-response/use-cases/UC5_Order_response.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OrderResponse xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:OrderResponse-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:order_response:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:ordering:3</cbc:ProfileID>
+  <cbc:ID>101</cbc:ID>
+  <cbc:IssueDate>2019-10-01</cbc:IssueDate>
+  <cbc:IssueTime>14:23:26</cbc:IssueTime>
+  <cbc:OrderResponseCode>AP</cbc:OrderResponseCode>
+  <cbc:DocumentCurrencyCode>SEK</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>5</cbc:ID>
+  </cac:OrderReference>
+  <cac:SellerSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0007">5546577799</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0007">5546577799</cbc:ID>
+      </cac:PartyIdentification>
+    </cac:Party>
+  </cac:SellerSupplierParty>
+   <cac:BuyerCustomerParty>
+     <cac:Party>
+       <cbc:EndpointID schemeID="0007">2041277711</cbc:EndpointID>
+       <cac:PartyIdentification>
+         <cbc:ID schemeID="0007">2041277711</cbc:ID>
+       </cac:PartyIdentification>
+     </cac:Party>
+   </cac:BuyerCustomerParty>
+  </OrderResponse>


### PR DESCRIPTION
- Add basic OrderResponse example XML files
- Add Singapore-specific OrderResponse example
- Include 5 Order Response use case examples:
  * UC1_Order_response through UC5_Order_response
- Complete the order lifecycle with response examples